### PR TITLE
Using Agg backend for matplotlib

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -46,6 +46,7 @@ __version__ = '2.0'
 
 import json
 import time
+import matplotlib; matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon


### PR DESCRIPTION
Using Agg backend, which is required for Tensorflow object detection API (release July 13th, 2018).

Otherwise, the same call will be executed by [visualization_utils](https://github.com/tensorflow/models/blob/master/research/object_detection/utils/visualization_utils.py#L25) and cause a crash, because other packages have been loaded previously.

BTW: Phil, it would be nice, if you could enable issues for this repository, for similar incidents.